### PR TITLE
feat: add function name to mock creation throw error

### DIFF
--- a/libs/ng-mockito/ng-mockito/src/lib/ts-mockito-helpers.spec.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/ts-mockito-helpers.spec.ts
@@ -34,6 +34,24 @@ describe('ts-mockito helpers', () => {
       }
     );
 
+    it.each`
+      argument                        | description         | expectedMessage
+      ${function myTestFunction() {}} | ${'named function'} | ${/myTestFunction/}
+      ${() => {
+  console.log('sample code');
+  console.log('2 sample code');
+}} | ${'arrow function'} | ${/sample code/}
+      ${function () {
+  console.log('sample code');
+  console.log('2 sample code');
+}} | ${'nameless function'} | ${/sample code/}
+    `(
+      'when using an $description should include $expectedMessage as info when throwing an error',
+      ({ argument, expectedMessage }) => {
+        expect(() => createTypeAndMock(argument)).toThrowError(expectedMessage);
+      }
+    );
+
     it('should create type and mock if type is given', () => {
       class Test {
         test() {

--- a/libs/ng-mockito/ng-mockito/src/lib/ts-mockito-helpers.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/ts-mockito-helpers.ts
@@ -19,12 +19,27 @@ export function createTypeAndMock<T>(
   } else if (isClass(typeOrMock)) {
     return { type: typeOrMock as Type<T>, mock: mock(typeOrMock) };
   } else {
+    const functionNameDetail = getFunctionNameDetail(typeOrMock);
     throw new Error(
-      `Given argument had invalid type: ${typeof typeOrMock}. Please provide a class or a ts-mockito mock.`
+      `Given argument had invalid type: ${typeof typeOrMock}${functionNameDetail}. Please provide a class or a ts-mockito mock.`
     );
   }
 }
 
+function getFunctionNameDetail(typeOrMock: any): string {
+  if (typeof typeOrMock !== 'function') {
+    return '';
+  }
+
+  if (typeOrMock.name === '') {
+    const functionInChars = typeOrMock.toString();
+    const firstCharsOfFunction = functionInChars.substring(0, 50);
+    return ` (${firstCharsOfFunction}...)`;
+  }
+
+  return ` (${typeOrMock.name})`;
+}
+getFunctionNameDetail.toString;
 function isClass(anything: unknown) {
   try {
     return (


### PR DESCRIPTION
# Why?

While migrating an existing project that already contains several mocks, if one of them is wrong (in my case it was a function) You have no idea which one was failing.

This PR adds a message like this:

![image](https://user-images.githubusercontent.com/5490201/104127962-3ae7bc80-5365-11eb-9e16-bd655022ab8a.png)

PD: A linting to staged files would be cool :)

PD2: Maybe I should put the first 15 chars of the function definition instead of "Anonymous Function" ? so you get something thing like 

```invalid type: function (  () => { somecode up to 15 chars })```