### PR TITLE
fix(ng-mockito): allow transpiled classes to be mocked

### DIFF
--- a/libs/ng-mockito/ng-mockito/src/lib/ts-mockito-helpers.spec.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/ts-mockito-helpers.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+import { HttpClient } from '@angular/common/http';
 import { instance, mock, when } from 'ts-mockito';
 import { createTypeAndMock, isStubbed } from './ts-mockito-helpers';
 
@@ -77,6 +78,10 @@ describe('ts-mockito helpers', () => {
       expect(typeAndMock.type).toBe(Test);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((typeAndMock.mock as any).__tsmockitoMocker.clazz).toBe(Test);
+    });
+
+    it('should accept transpiled classes', () => {
+      expect(() => createTypeAndMock(HttpClient)).not.toThrow();
     });
   });
 

--- a/libs/ng-mockito/ng-mockito/src/lib/ts-mockito-helpers.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/ts-mockito-helpers.ts
@@ -39,12 +39,13 @@ function getFunctionNameDetail(typeOrMock: any): string {
 
   return ` (${typeOrMock.name})`;
 }
-getFunctionNameDetail.toString;
+
 function isClass(anything: unknown) {
   try {
     return (
       typeof anything === 'function' &&
-      anything.toString()?.trim().startsWith('class')
+      ('ctorParameters' in anything ||
+        anything.toString()?.trim().startsWith('class'))
     );
   } catch (e) {
     throw new Error(


### PR DESCRIPTION
before this, transpiled classes like Angular's HttpClient were rejected, because
they were not recognized as classes

fixes #22