### PR TITLE
fix(ng-mockito): allow Angular >= v11 as peer dependency

### DIFF
--- a/libs/ng-mockito/ng-mockito/package.json
+++ b/libs/ng-mockito/ng-mockito/package.json
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@angular/common": "^10.1.6",
-    "@angular/core": "^10.1.6",
+    "@angular/common": ">=10.1.6",
+    "@angular/core": ">=10.1.6",
     "ts-mockito": "^2.6.1"
   },
   "dependencies": {


### PR DESCRIPTION
fixes #26