### PR TITLE
fix(ng-mockito): allow mocking of transpiled abstract classes like Renderer2

### DIFF
--- a/libs/ng-mockito/ng-mockito/src/lib/mock-component.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/mock-component.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Component, EventEmitter, Type } from '@angular/core';
+import { Component, EventEmitter } from '@angular/core';
 import { instance, when } from 'ts-mockito';
 import {
   getDirectiveProperties,
   getDecoratorMetadata,
 } from './ng-decorator-helpers';
 import { createTypeAndMock, noOp, isStubbed } from './ts-mockito-helpers';
-import { SetupMockFn, TypeOrMock } from './types';
+import { SetupMockFn, TypeOrMock, Type } from './types';
 
 /**
  * Returns a mocked version of the given component.

--- a/libs/ng-mockito/ng-mockito/src/lib/mock-directive.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/mock-directive.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Directive, EventEmitter, Type } from '@angular/core';
+import { Directive, EventEmitter } from '@angular/core';
 import { instance, when } from 'ts-mockito';
 import {
   getDecoratorMetadata,
   getDirectiveProperties,
 } from './ng-decorator-helpers';
 import { createTypeAndMock, isStubbed, noOp } from './ts-mockito-helpers';
-import { SetupMockFn, TypeOrMock } from './types';
+import { SetupMockFn, TypeOrMock, Type } from './types';
 
 /**
  * Returns a mocked version of the given directive.

--- a/libs/ng-mockito/ng-mockito/src/lib/mock-ng.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/mock-ng.ts
@@ -1,4 +1,4 @@
-import { FactoryProvider, InjectionToken, Type } from '@angular/core';
+import { FactoryProvider, InjectionToken } from '@angular/core';
 import { mockComponent } from './mock-component';
 import { mockDirective } from './mock-directive';
 import { mockPipe } from './mock-pipe';
@@ -6,7 +6,7 @@ import { mockProvider } from './mock-provider';
 import { mockToken, TokenWithClient, TokenConfigOrSetup } from './mock-token';
 import { getDecoratorNames } from './ng-decorator-helpers';
 import { createTypeAndMock, noOp } from './ts-mockito-helpers';
-import { SetupMockFn, TypeOrMock } from './types';
+import { SetupMockFn, TypeOrMock, Type } from './types';
 
 type TypeOrMockButNotArrayLike<T> = T extends unknown[]
   ? never // exclude array-likes, otherwise TokenWithClient could be inferred as TypeOrMock

--- a/libs/ng-mockito/ng-mockito/src/lib/mock-pipe.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/mock-pipe.ts
@@ -1,8 +1,8 @@
-import { Pipe, Type } from '@angular/core';
+import { Pipe } from '@angular/core';
 import { instance } from 'ts-mockito';
 import { getDecoratorMetadata } from './ng-decorator-helpers';
 import { createTypeAndMock, noOp } from './ts-mockito-helpers';
-import { SetupMockFn, TypeOrMock } from './types';
+import { SetupMockFn, TypeOrMock, Type } from './types';
 
 /**
  * Returns a mocked version of the given pipe.

--- a/libs/ng-mockito/ng-mockito/src/lib/ng-decorator-helpers.spec.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/ng-decorator-helpers.spec.ts
@@ -1,3 +1,4 @@
+import { Type } from './types';
 import {
   Component,
   Directive,
@@ -7,7 +8,6 @@ import {
   Output,
   Pipe,
   PipeTransform,
-  Type,
 } from '@angular/core';
 import {
   getDecoratorMetadata,

--- a/libs/ng-mockito/ng-mockito/src/lib/ng-decorator-helpers.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/ng-decorator-helpers.ts
@@ -1,10 +1,11 @@
+import { Type } from './types';
 import {
   Component,
   Directive,
   Injectable,
   Pipe,
-  Type,
   ɵReflectionCapabilities,
+  Type as NgType,
 } from '@angular/core';
 
 type DecoratorName = 'Pipe' | 'Component' | 'Directive' | 'Injectable';
@@ -22,7 +23,9 @@ type Decorator<D> = D extends 'Pipe'
 const reflection = new ɵReflectionCapabilities();
 
 export function getDecoratorNames<T>(decoratedClass: Type<T>): DecoratorName[] {
-  return reflection.annotations(decoratedClass).map((a) => a.ngMetadataName);
+  return reflection
+    .annotations(decoratedClass as NgType<T>)
+    .map((a) => a.ngMetadataName);
 }
 
 export function getDecoratorMetadata<T, D extends DecoratorName>(
@@ -30,7 +33,9 @@ export function getDecoratorMetadata<T, D extends DecoratorName>(
   decoratorName: D
 ): Decorator<D> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const annotations: any[] = reflection.annotations(decoratedClass);
+  const annotations: any[] = reflection.annotations(
+    decoratedClass as NgType<T>
+  );
   const decorator = annotations.find((a) => a.ngMetadataName === decoratorName);
   if (!decorator) {
     throw new Error(

--- a/libs/ng-mockito/ng-mockito/src/lib/ts-mockito-helpers.spec.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/ts-mockito-helpers.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { DOCUMENT } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { InjectionToken } from '@angular/core';
+import { InjectionToken, Renderer2 } from '@angular/core';
 import { instance, mock, when } from 'ts-mockito';
 import { createTypeAndMock, isStubbed, isMock } from './ts-mockito-helpers';
 
@@ -55,12 +55,21 @@ describe('ts-mockito helpers', () => {
       }
     );
 
-    it('should create type and mock if type is given', () => {
+    it('should create type and mock if class is given', () => {
       class Test {
         test() {
           throw new Error('real implementation used.');
         }
       }
+      const typeAndMock = createTypeAndMock(Test);
+
+      expect(typeAndMock.type).toBe(Test);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((typeAndMock.mock as any).__tsmockitoMocker.clazz).toBe(Test);
+    });
+
+    it('should create type and mock if abstract class is given', () => {
+      abstract class Test {}
       const typeAndMock = createTypeAndMock(Test);
 
       expect(typeAndMock.type).toBe(Test);
@@ -84,6 +93,10 @@ describe('ts-mockito helpers', () => {
 
     it('should accept transpiled classes', () => {
       expect(() => createTypeAndMock(HttpClient)).not.toThrow();
+    });
+
+    it('should accept transpiled abstract classes', () => {
+      expect(() => createTypeAndMock(Renderer2)).not.toThrow();
     });
 
     it.each`

--- a/libs/ng-mockito/ng-mockito/src/lib/ts-mockito-helpers.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/ts-mockito-helpers.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { InjectionToken, Type } from '@angular/core';
+import { InjectionToken } from '@angular/core';
 import { mock } from 'ts-mockito';
 import { Mocker } from 'ts-mockito/lib/Mock';
-import { TypeAndMock, TypeOrMock } from './types';
+import { TypeAndMock, TypeOrMock, Type } from './types';
 
 export function createTypeAndMock<T>(
   typeOrMock: TypeOrMock<T>
@@ -26,7 +26,7 @@ export function createTypeAndMock<T>(
       `
     );
   } else if (typeof typeOrMock === 'object') {
-    return { type: getMockedClass(typeOrMock), mock: typeOrMock };
+    return { type: getMockedClass(typeOrMock), mock: typeOrMock as T };
   } else if (isClass(typeOrMock)) {
     return { type: typeOrMock as Type<T>, mock: mock(typeOrMock) };
   } else {
@@ -53,11 +53,17 @@ function getFunctionNameDetail(typeOrMock: any): string {
 }
 
 function isClass(anything: unknown) {
+  function startsWithUppercaseLetter(s?: string) {
+    // as a last resort, we trust that constructor functions start with upper-case letters
+    return !!s && s.length > 0 && s[0].toUpperCase() === s[0];
+  }
+
   try {
     return (
       typeof anything === 'function' &&
       ('ctorParameters' in anything ||
-        anything.toString()?.trim().startsWith('class'))
+        anything.toString()?.trim().startsWith('class') ||
+        startsWithUppercaseLetter(anything.name))
     );
   } catch (e) {
     throw new Error(

--- a/libs/ng-mockito/ng-mockito/src/lib/types.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/types.ts
@@ -1,4 +1,5 @@
-import { Type } from '@angular/core';
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type Type<T> = Function & { prototype: T };
 
 export type TypeOrMock<T> = Type<T> | T;
 export type TypeAndMock<T> = { type: Type<T>; mock: T };


### PR DESCRIPTION
We didn't recognize transpiled abstract classes like Angular's Renderer2 as valid mock targets, because we can't distinguish them from normal functions. As a work-around, we now allow all functions that start with an uppercase letter, believing in the good in people. 😇️