### PR TITLE
fix(ng-mockito): don't use named tuples

### DIFF
--- a/libs/ng-mockito/ng-mockito/package.json
+++ b/libs/ng-mockito/ng-mockito/package.json
@@ -25,7 +25,8 @@
   "peerDependencies": {
     "@angular/common": ">=10.1.6",
     "@angular/core": ">=10.1.6",
-    "ts-mockito": "^2.6.1"
+    "ts-mockito": "^2.6.1",
+    "typescript": ">=3.9.0"
   },
   "dependencies": {
     "tslib": "^2.0.0"

--- a/libs/ng-mockito/ng-mockito/src/lib/mock-token.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/mock-token.ts
@@ -12,9 +12,10 @@ import {
 import { SetupMockFn } from './types';
 import { isMock } from './ts-mockito-helpers';
 
-export type TokenWithClient<T, U> = Readonly<
-  [token: InjectionToken<T>, client: Type<U>]
->;
+/**
+ * Tuple of an injection token and its client (e.g. the service injecting this token).
+ */
+export type TokenWithClient<T, U> = Readonly<[InjectionToken<T>, Type<U>]>;
 
 export type TokenConfigValue<T> = { use: T };
 


### PR DESCRIPTION
Don't use named tuples, because they break projects with typescript versions below v4.0.0