### PR TITLE
fix(ng-mockito): support providing classes without Injectable decorator in mockNg

### DIFF
--- a/libs/ng-mockito/ng-mockito/src/lib/mock-ng.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/mock-ng.ts
@@ -57,11 +57,9 @@ export function mockNg<T, U>(
     return mockDirective(mock, setup);
   }
 
-  if (decoratorNames.includes('Injectable')) {
-    return mockProvider(mock, setup);
-  }
-
-  throw new Error('Unknown decorator.');
+  // Injectable decorator or no decorator (in which case
+  // we guess that it must be a class to be provided, like ActivatedRoute)
+  return mockProvider(mock, setup);
 }
 
 function isTokenWithClient<T, U>(

--- a/libs/ng-mockito/ng-mockito/src/lib/mock-provider.spec.ts
+++ b/libs/ng-mockito/ng-mockito/src/lib/mock-provider.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import * as tsMockito from 'ts-mockito';
 import { mockNg } from './mock-ng';
 import { mockProvider as _mockProvider } from './mock-provider';
+import { ActivatedRoute } from '@angular/router';
 
 describe.each`
   mockProvider     | description
@@ -35,7 +36,15 @@ describe.each`
       expect(() => mockProvider('test')).toThrowError(/invalid type./);
     });
 
-    describe('integration', () => {
+    it('should mock ActivatedRoute', () => {
+      TestBed.configureTestingModule({
+        providers: [mockProvider(ActivatedRoute)],
+      });
+
+      expect(TestBed.inject(ActivatedRoute)).toBeDefined();
+    });
+
+    describe('with test service', () => {
       @Injectable({
         providedIn: 'root',
       })


### PR DESCRIPTION
fixes #31